### PR TITLE
feat: add method to send canvas message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.5]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+feat: add send_canvas_message method
+
 [0.1.4]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 feat: add identify_users method

--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'

--- a/braze/constants.py
+++ b/braze/constants.py
@@ -9,6 +9,7 @@ class BrazeAPIEndpoints:
     """
 
     SEND_CAMPAIGN = '/campaigns/trigger/send'
+    SEND_CANVAS = '/canvas/trigger/send'
     EXPORT_IDS = '/users/export/ids'
     SEND_MESSAGE = '/messages/send'
     NEW_ALIAS = '/users/alias/new'


### PR DESCRIPTION
Add a method to send API triggered canvas message.
Braze API reference: https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_triggered_canvases/

Ticket: https://2u-internal.atlassian.net/browse/VAN-1142