### PR TITLE
feat: add method to unsubscribe user email

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.6]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+feat: add unsubscribe_user_email method
+
 [0.1.5]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 feat: add send_canvas_message method

--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'

--- a/braze/client.py
+++ b/braze/client.py
@@ -8,7 +8,12 @@ from urllib.parse import urljoin
 
 import requests
 
-from braze.constants import TRACK_USER_COMPONENT_CHUNK_SIZE, USER_ALIAS_CHUNK_SIZE, BrazeAPIEndpoints
+from braze.constants import (
+    TRACK_USER_COMPONENT_CHUNK_SIZE,
+    UNSUBSCRIBED_STATE,
+    USER_ALIAS_CHUNK_SIZE,
+    BrazeAPIEndpoints,
+)
 
 from .exceptions import (
     BrazeBadRequestError,
@@ -400,3 +405,33 @@ class BrazeClient:
         }
 
         return self._post_request(message, BrazeAPIEndpoints.SEND_CANVAS)
+
+    def unsubscribe_user_email(
+        self,
+        email
+    ):
+        """
+        Unsubscribe user's email via API.
+
+        https://www.braze.com/docs/api/endpoints/email/post_email_subscription_status/
+
+        Arguments:
+            email (str, list): The maximum number of emails in a list can be 50 or just one str
+            e.g. 'test1@example.com' or ['test2@example.com', 'test3@example.com', ...]
+        Returns:
+            response (dict): The response object
+        """
+        if not email:
+            msg = 'Bad arguments, please check that emails are non-empty.'
+            raise BrazeClientError(msg)
+
+        if isinstance(email, list) and len(email) > 50:
+            msg = 'Bad arguments, The maximum number of emails in a list can be 50.'
+            raise BrazeClientError(msg)
+
+        payload = {
+            'email': email,
+            'subscription_state': UNSUBSCRIBED_STATE
+        }
+
+        return self._post_request(payload, BrazeAPIEndpoints.UNSUBSCRIBE_USER_EMAIL)

--- a/braze/constants.py
+++ b/braze/constants.py
@@ -15,8 +15,10 @@ class BrazeAPIEndpoints:
     NEW_ALIAS = '/users/alias/new'
     TRACK_USER = '/users/track'
     IDENTIFY_USERS = '/users/identify'
+    UNSUBSCRIBE_USER_EMAIL = '/email/status'
 
 
 # Braze enforced request size limits
 TRACK_USER_COMPONENT_CHUNK_SIZE = 75
 USER_ALIAS_CHUNK_SIZE = 50
+UNSUBSCRIBED_STATE = 'unsubscribed'


### PR DESCRIPTION
Add a method to unsubscribe user email on Braze.

Braze API reference: https://www.braze.com/docs/api/endpoints/email/post_email_subscription_status/

Ticket: [VAN-1274](https://2u-internal.atlassian.net/browse/VAN-1274)