### PR TITLE
build: update how codecov is invoked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,8 @@ jobs:
           TOXENV: ${{ matrix.toxenv }}
         run: tox
       - name: Run code coverage
-        run: codecov
+        if: matrix.python-version == '3.8' && matrix.toxenv=='py38'
+        uses: codecov/codecov-action@v3
+        with:
+            fail_ci_if_error: true
+

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests on CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,8 +10,6 @@ certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.7
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==6.0.2
     # via codecov
 distlib==0.3.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -49,8 +49,6 @@ code-annotations==1.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
 colorama==0.4.4
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
old way using pypi package was deprecated

On Wednesday this happened with Codecov: https://about.codecov.io/blog/message-regarding-the-pypi-package/

Since codecov's GHA-based uploader doesn't depend on the `codecov` python package, this PR removes it.