### PR TITLE
feat: add retrieve unsubscribed emails from braze method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.7]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+feat: add retrieve_unsubscribed_emails method
+
 [0.1.6]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 feat: add unsubscribe_user_email method

--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'

--- a/braze/constants.py
+++ b/braze/constants.py
@@ -16,9 +16,14 @@ class BrazeAPIEndpoints:
     TRACK_USER = '/users/track'
     IDENTIFY_USERS = '/users/identify'
     UNSUBSCRIBE_USER_EMAIL = '/email/status'
+    UNSUBSCRIBED_EMAILS = '/email/unsubscribes'
 
 
 # Braze enforced request size limits
+REQUEST_TYPE_GET = 'get'
+REQUEST_TYPE_POST = 'post'
 TRACK_USER_COMPONENT_CHUNK_SIZE = 75
 USER_ALIAS_CHUNK_SIZE = 50
 UNSUBSCRIBED_STATE = 'unsubscribed'
+UNSUBSCRIBED_EMAILS_API_LIMIT = 500
+UNSUBSCRIBED_EMAILS_API_SORT_DIRECTION = 'desc'


### PR DESCRIPTION
Add a method to retrieve unsubscribed emails from Braze and its corresponding tests.
Braze API reference: https://www.braze.com/docs/api/endpoints/email/get_query_unsubscribed_email_addresses/

Ticket: [VAN-1466](https://2u-internal.atlassian.net/browse/VAN-1466)