### PR TITLE
feat: update pypa's publish branch away from master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build package
         run: python setup.py sdist bdist_wheel
       - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
Update publish workflow to point away from master and to the documentation's stated branch

https://github.com/pypa/gh-action-pypi-publish

Other related PRs:
https://github.com/openedx/edx-enterprise/pull/1835
https://github.com/openedx/edx-enterprise-data/pull/386
https://github.com/openedx/enterprise-subsidy/pull/143
https://github.com/openedx/edx-rest-api-client/pull/288
https://github.com/openedx/openedx-ledger/pull/32
https://github.com/openedx/ecommerce-worker/pull/205
https://github.com/openedx/edx-rbac/pull/247
https://github.com/openedx/edx-analytics-data-api-client/pull/135
