### PR TITLE
fix: always create an alias for existing profiles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.8]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+fix: always create an alias for existing profiles
+
 [0.1.7]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 feat: add retrieve_unsubscribed_emails method

--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'

--- a/braze/client.py
+++ b/braze/client.py
@@ -222,17 +222,22 @@ class BrazeClient:
         attributes = attributes or []
 
         for email in emails:
-            if not self.get_braze_external_id(email):
-                user_alias = {
-                    'alias_label': alias_label,
-                    'alias_name': email,
-                }
-                user_aliases.append(user_alias)
-                attribute = {
-                    'user_alias': user_alias,
-                    'email': email,
-                }
-                attributes.append(attribute)
+            user_alias = {
+                'alias_label': alias_label,
+                'alias_name': email,
+            }
+            braze_external_id = self.get_braze_external_id(email)
+            # Adding a user alias for an existing user requires an external_id to be
+            # included in the new user alias object.
+            # http://web.archive.org/web/20231005191135/https://www.braze.com/docs/api/endpoints/user_data/post_user_alias#response
+            if braze_external_id:
+                user_alias['external_id'] = braze_external_id
+            user_aliases.append(user_alias)
+            attribute = {
+                'user_alias': user_alias,
+                'email': email,
+            }
+            attributes.append(attribute)
 
         # Each request can support up to 50 aliases.
         for user_alias_chunk in self._chunks(user_aliases, USER_ALIAS_CHUNK_SIZE):


### PR DESCRIPTION
## Description

Even when an alias involves a profile with an `external_id` we still want to create the alias for use elsewhere.

I have tested by hand that this is idempotent and can be called multiple times for an existing profile with an existing alias.

- https://2u-internal.atlassian.net/browse/ENT-7795