### PR TITLE
User export enhancements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.9]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+feat: add user export by external ID
+feat: add function to trigger user segment export
+
 [0.1.8]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 fix: always create an alias for existing profiles

--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '0.1.8'
+__version__ = '0.1.9'

--- a/braze/client.py
+++ b/braze/client.py
@@ -135,6 +135,26 @@ class BrazeClient:
 
         return None
 
+    def get_braze_users_by_external_id(self, external_ids):
+        """
+        Export user profiles from Braze based on their external_id.
+
+        https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/
+
+        Arguments:
+            external_ids (list[str]): e.g. ['abc1', 'def2]
+        Returns:
+            users (list of dicts): user profiles if specified accounts exists
+        """
+        payload = {
+            'external_ids': external_ids,
+        }
+        response = self._make_request(payload, BrazeAPIEndpoints.EXPORT_IDS, REQUEST_TYPE_POST)
+        if response['users']:
+            return response['users']
+
+        return None
+
     def identify_users(self, aliases_to_identify):
         """
         Identify unidentified (alias-only) users.

--- a/braze/client.py
+++ b/braze/client.py
@@ -155,6 +155,34 @@ class BrazeClient:
 
         return None
 
+    def start_braze_segment_user_export(self, segment_id, required_fields, output_gzip=False):
+        """
+        Export files of user profiles from Braze to object store based on a segment ID (defaults to zip format).
+
+        https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/
+
+        Arguments:
+            segment_id (str): e.g. 'abc1
+            required_fields (list[str]): list of fields to include in export
+            output_gzip (bool): set export format to gzip, defaults to False
+        Returns:
+            response (dict[str, str]):
+                url: object store URL of export if none setup on customer end (optional)
+                object_prefix: prefix of exported file(s)
+                message: status of export; 'success' if no errors
+        """
+        payload = {
+            'segment_id': segment_id,
+            'fields_to_export': required_fields,
+            'output_format': "gzip" if output_gzip else "zip",
+        }
+        response = self._make_request(payload, BrazeAPIEndpoints.EXPORT_SEGMENT, REQUEST_TYPE_POST)
+
+        if response:
+            return response
+
+        return None
+
     def identify_users(self, aliases_to_identify):
         """
         Identify unidentified (alias-only) users.

--- a/braze/constants.py
+++ b/braze/constants.py
@@ -11,6 +11,7 @@ class BrazeAPIEndpoints:
     SEND_CAMPAIGN = '/campaigns/trigger/send'
     SEND_CANVAS = '/canvas/trigger/send'
     EXPORT_IDS = '/users/export/ids'
+    EXPORT_SEGMENT = '/users/export/segment'
     SEND_MESSAGE = '/messages/send'
     NEW_ALIAS = '/users/alias/new'
     TRACK_USER = '/users/track'

--- a/tests/braze/test_client.py
+++ b/tests/braze/test_client.py
@@ -93,6 +93,49 @@ class BrazeClientTests(TestCase):
         assert len(responses.calls) == 1
         assert responses.calls[0].request.url == self.EXPORT_ID_URL
 
+    @responses.activate
+    def test_get_braze_users_by_external_id_success(self):
+        """
+        Tests a successful call to the /users/export/ids endpoint to retrieve
+        users' data from list of `external_id` values.
+        """
+
+        TEST_USERS = [
+            {'external_id': 'abc1', 'email': 'foo@example.com', 'first_name': 'Foo'},
+            {'external_id': 'def2', 'email': 'bar@example.com', 'first_name': 'Bar'},
+        ]
+
+        responses.add(
+            responses.POST,
+            self.EXPORT_ID_URL,
+            json={'users': TEST_USERS,
+                  'message': 'success'},
+            status=201
+        )
+        user_data = self.client.get_braze_users_by_external_id(external_ids=['abc1', 'def2'])
+
+        self.assertEqual(user_data, TEST_USERS)
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == self.EXPORT_ID_URL
+
+    @responses.activate
+    def test_get_braze_users_by_external_id_failure(self):
+        """
+        Tests a call to the /users/export/ids endpoint to retrieve a user's data
+        with an invalid external_id.
+        """
+        responses.add(
+            responses.POST,
+            self.EXPORT_ID_URL,
+            json={'users': [], 'invalid_user_ids': ['xyz321'], 'message': 'success'},
+            status=201
+        )
+        user_data = self.client.get_braze_users_by_external_id(external_ids=['xyz321'])
+
+        assert user_data is None
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == self.EXPORT_ID_URL
+
     def test_identify_users_bad_args(self):
         """
         Tests that arguments are validated.


### PR DESCRIPTION
Adds user export functionality:

* export by external ID (see Braze  [Export user profile by identifier](https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/) endpoint docs)
* trigger segment export to object store (see Braze [Export user profile by segment](https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/) endpoint docs)

Apologies, I've combined two small features in this PR - I hope that's okay. My time at work is pretty scarce at the mo and I'm only getting around to creating this request during my holidays.

Detailed information in commits.
