### PR TITLE
feat: check for external ids in batches when creating aliases.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.2.0]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+feat: check for external ids in batchs when creating aliases.
+
 [0.1.8]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 fix: always create an alias for existing profiles

--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,9 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 
 quality: ## check coding style with pycodestyle and pylint
 	touch tests/__init__.py
-	pylint braze tests test_utils manage.py *.py
+	pylint braze tests test_utils *.py
 	pycodestyle braze tests  *.py
-	pydocstyle braze tests *.py
-	isort --check-only --diff --recursive tests test_utils braze *.py test_settings.py
-	python setup.py bdist_wheel
-	twine check dist/*
-	make selfcheck
-
+	isort --check-only --diff --recursive tests test_utils braze *.py
 
 requirements: ## install development environment requirements
 	pip install -r requirements/pip.txt

--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '0.1.8'
+__version__ = '0.2.0'

--- a/braze/constants.py
+++ b/braze/constants.py
@@ -24,6 +24,10 @@ REQUEST_TYPE_GET = 'get'
 REQUEST_TYPE_POST = 'post'
 TRACK_USER_COMPONENT_CHUNK_SIZE = 75
 USER_ALIAS_CHUNK_SIZE = 50
+
+# https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/?tab=all%20fields
+GET_EXTERNAL_IDS_CHUNK_SIZE = 50
+
 UNSUBSCRIBED_STATE = 'unsubscribed'
 UNSUBSCRIBED_EMAILS_API_LIMIT = 500
 UNSUBSCRIBED_EMAILS_API_SORT_DIRECTION = 'desc'

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ multi_line_output = 3
 
 [wheel]
 universal = 1
+
+[flake8]
+max_line_length = 120


### PR DESCRIPTION
ENT-8325 | Query `/users/export/ids` using batches of alias records when checking for existing accounts/external ids in `create_braze_alias()`.  This means we'll go from one call per email/alias to one call *per batch* of emails to create aliases for.  This will help us avoid rate-limiting when creating many batches of braze alias records.

https://2u-internal.atlassian.net/browse/ENT-8325