### PR TITLE
fix: be defensive about pulling both email and external_id from braze…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.2.2]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+fix: be defensive about pulling both ``email`` and ``external_id`` from braze export.
+
 [0.2.1]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 fix: be defensive about pulling external_id from braze export.

--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/braze/client.py
+++ b/braze/client.py
@@ -177,7 +177,10 @@ class BrazeClient:
             response = self._make_request(payload, BrazeAPIEndpoints.EXPORT_IDS, REQUEST_TYPE_POST)
 
             for identified_user in response['users']:
-                external_ids_by_email[identified_user['email']] = identified_user.get('external_id')
+                identified_email = identified_user.get('email')
+                external_id = identified_user.get('external_id')
+                if identified_email and external_id:
+                    external_ids_by_email[identified_email] = external_id
 
         logger.info(f'external ids from batch identify braze users response: {external_ids_by_email}')
         return external_ids_by_email

--- a/tests/braze/test_client.py
+++ b/tests/braze/test_client.py
@@ -257,7 +257,14 @@ class BrazeClientTests(TestCase):
         responses.add(
             responses.POST,
             self.EXPORT_ID_URL,
-            json={'users': [{'external_id': existing_enternal_id, 'email': test_email}], 'message': 'success'},
+            json={
+                'users': [
+                    {'external_id': existing_enternal_id, 'email': test_email},
+                    {'external_id': '123'},
+                    {},
+                ],
+                'message': 'success'
+            },
             status=201
         )
         responses.add(


### PR DESCRIPTION
… export. 
Apparently the export-users endpoint will export records with no "email" in them? 🤷 