### PR TITLE
build: skip twine check in pypi publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+          verify-metadata: false


### PR DESCRIPTION
Skipping for now to get around `long_description` syntax error.