### PR TITLE
fix: braze_client settings & bump version

### DIFF
--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/braze/settings/common.py
+++ b/braze/settings/common.py
@@ -7,7 +7,11 @@ def plugin_settings(settings):
     """
     Common settings for braze app
     """
+    env_tokens = getattr(settings, "ENV_TOKENS", {})
+
     # BRAZE API SETTINGS
-    settings.EDX_BRAZE_API_KEY = None
-    settings.EDX_BRAZE_API_SERVER = None
-    settings.BRAZE_COURSE_ENROLLMENT_CANVAS_ID = ""
+    settings.EDX_BRAZE_API_KEY = env_tokens.get("EDX_BRAZE_API_KEY", None)
+    settings.EDX_BRAZE_API_SERVER = env_tokens.get("EDX_BRAZE_API_SERVER", None)
+    settings.BRAZE_COURSE_ENROLLMENT_CANVAS_ID = env_tokens.get(
+        "BRAZE_COURSE_ENROLLMENT_CANVAS_ID", ""
+    )


### PR DESCRIPTION
This PR fixes the bug as these settings weren't picking/overriding values from edx-internal. 
So, in this PR:
- we used ENV_TOKENS to capture the right settings.
- bumped version.