### PR TITLE
feat: Added ace channel for braze messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.1.1]
+^^^^^^^
+- Adds edx-ace Channel for Braze messages
+
 [1.0.0]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Breaking Change] converts braze library to python djangoapp

--- a/braze/__init__.py
+++ b/braze/__init__.py
@@ -2,4 +2,4 @@
 Python client for interacting with Braze APIs.
 """
 
-__version__ = '1.0.2'
+__version__ = '1.1.1'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,3 +4,4 @@
 Django              # Web application framework
 edx-django-utils
 requests
+edx-ace

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,47 +4,182 @@
 #
 #    make upgrade
 #
+anyio==4.9.0
+    # via httpx
 asgiref==3.8.1
     # via django
+attrs==25.3.0
+    # via edx-ace
+cachecontrol==0.14.3
+    # via firebase-admin
+cachetools==5.5.2
+    # via google-auth
 certifi==2025.1.31
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cffi==1.17.1
-    # via pynacl
+    # via
+    #   cryptography
+    #   pynacl
 charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via edx-django-utils
+cryptography==45.0.4
+    # via pyjwt
 django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   django-crum
+    #   django-push-notifications
     #   django-waffle
+    #   edx-ace
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
+django-push-notifications==3.2.1
+    # via edx-ace
 django-waffle==4.2.0
     # via edx-django-utils
-edx-django-utils==7.2.0
+edx-ace==1.15.0
     # via -r requirements/base.in
+edx-django-utils==7.2.0
+    # via
+    #   -r requirements/base.in
+    #   edx-ace
+firebase-admin==6.9.0
+    # via edx-ace
+google-api-core[grpc]==2.25.1
+    # via
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.174.0
+    # via firebase-admin
+google-auth==2.40.3
+    # via
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via google-api-python-client
+google-cloud-core==2.4.3
+    # via
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.21.0
+    # via firebase-admin
+google-cloud-storage==3.1.1
+    # via firebase-admin
+google-crc32c==1.7.1
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via google-cloud-storage
+googleapis-common-protos==1.70.0
+    # via
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.73.1
+    # via
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.73.1
+    # via google-api-core
+h11==0.16.0
+    # via httpcore
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
+httpcore==1.0.9
+    # via httpx
+httplib2==0.22.0
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
+httpx[http2]==0.28.1
+    # via firebase-admin
+hyperframe==6.1.0
+    # via h2
 idna==3.10
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
+msgpack==1.1.1
+    # via cachecontrol
 newrelic==10.7.0
     # via edx-django-utils
 pbr==6.1.1
     # via stevedore
+proto-plus==1.26.1
+    # via
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==6.31.1
+    # via
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
 psutil==7.0.0
     # via edx-django-utils
+pyasn1==0.6.1
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.2
+    # via google-auth
 pycparser==2.22
     # via cffi
+pyjwt[crypto]==2.10.1
+    # via firebase-admin
 pynacl==1.5.0
     # via edx-django-utils
+pyparsing==3.2.3
+    # via httplib2
+python-dateutil==2.9.0.post0
+    # via edx-ace
 requests==2.32.3
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   cachecontrol
+    #   google-api-core
+    #   google-cloud-storage
+    #   sailthru-client
+rsa==4.9.1
+    # via google-auth
+sailthru-client==2.2.3
+    # via edx-ace
+simplejson==3.20.1
+    # via sailthru-client
+six==1.17.0
+    # via
+    #   edx-ace
+    #   python-dateutil
+sniffio==1.3.1
+    # via anyio
 sqlparse==0.5.3
     # via django
 stevedore==5.4.1
-    # via edx-django-utils
+    # via
+    #   edx-ace
+    #   edx-django-utils
+typing-extensions==4.14.0
+    # via anyio
+uritemplate==4.2.0
+    # via google-api-python-client
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+anyio==4.9.0
+    # via
+    #   -r requirements/quality.txt
+    #   httpx
 asgiref==3.8.1
     # via
     #   -r requirements/quality.txt
@@ -13,6 +17,10 @@ astroid==3.3.8
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
+attrs==25.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-ace
 backports-tarfile==1.2.0
     # via
     #   -r requirements/quality.txt
@@ -21,17 +29,26 @@ build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+cachecontrol==0.14.3
+    # via
+    #   -r requirements/quality.txt
+    #   firebase-admin
 cachetools==5.5.2
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
+    #   google-auth
     #   tox
 certifi==2025.1.31
     # via
     #   -r requirements/quality.txt
+    #   httpcore
+    #   httpx
     #   requests
 cffi==1.17.1
     # via
     #   -r requirements/quality.txt
+    #   cryptography
     #   pynacl
 chardet==5.2.0
     # via
@@ -67,6 +84,10 @@ coverage[toml]==7.6.12
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
+cryptography==45.0.4
+    # via
+    #   -r requirements/quality.txt
+    #   pyjwt
 ddt==1.7.2
     # via -r requirements/quality.txt
 diff-cover==9.2.3
@@ -84,12 +105,18 @@ django==4.2.20
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   django-crum
+    #   django-push-notifications
     #   django-waffle
+    #   edx-ace
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
+django-push-notifications==3.2.1
+    # via
+    #   -r requirements/quality.txt
+    #   edx-ace
 django-waffle==4.2.0
     # via
     #   -r requirements/quality.txt
@@ -98,8 +125,12 @@ docutils==0.21.2
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-edx-django-utils==7.2.0
+edx-ace==1.15.0
     # via -r requirements/quality.txt
+edx-django-utils==7.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-ace
 edx-lint==5.6.0
     # via -r requirements/quality.txt
 filelock==3.17.0
@@ -107,6 +138,100 @@ filelock==3.17.0
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
+firebase-admin==6.9.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-ace
+google-api-core[grpc]==2.25.1
+    # via
+    #   -r requirements/quality.txt
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.174.0
+    # via
+    #   -r requirements/quality.txt
+    #   firebase-admin
+google-auth==2.40.3
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-python-client
+google-cloud-core==2.4.3
+    # via
+    #   -r requirements/quality.txt
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.21.0
+    # via
+    #   -r requirements/quality.txt
+    #   firebase-admin
+google-cloud-storage==3.1.1
+    # via
+    #   -r requirements/quality.txt
+    #   firebase-admin
+google-crc32c==1.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via
+    #   -r requirements/quality.txt
+    #   google-cloud-storage
+googleapis-common-protos==1.70.0
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.73.1
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.73.1
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-core
+h11==0.16.0
+    # via
+    #   -r requirements/quality.txt
+    #   httpcore
+h2==4.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   httpx
+hpack==4.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   h2
+httpcore==1.0.9
+    # via
+    #   -r requirements/quality.txt
+    #   httpx
+httplib2==0.22.0
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-python-client
+    #   google-auth-httplib2
+httpx[http2]==0.28.1
+    # via
+    #   -r requirements/quality.txt
+    #   firebase-admin
+hyperframe==6.1.0
+    # via
+    #   -r requirements/quality.txt
+    #   h2
 id==1.5.0
     # via
     #   -r requirements/quality.txt
@@ -114,6 +239,8 @@ id==1.5.0
 idna==3.10
     # via
     #   -r requirements/quality.txt
+    #   anyio
+    #   httpx
     #   requests
 importlib-metadata==8.6.1
     # via
@@ -169,6 +296,10 @@ more-itertools==10.6.0
     #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
+msgpack==1.1.1
+    # via
+    #   -r requirements/quality.txt
+    #   cachecontrol
 newrelic==10.7.0
     # via
     #   -r requirements/quality.txt
@@ -207,10 +338,32 @@ pluggy==1.5.0
     #   diff-cover
     #   pytest
     #   tox
+proto-plus==1.26.1
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==6.31.1
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
 psutil==7.0.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
+pyasn1==0.6.1
+    # via
+    #   -r requirements/quality.txt
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.2
+    # via
+    #   -r requirements/quality.txt
+    #   google-auth
 pycodestyle==2.12.1
     # via -r requirements/quality.txt
 pycparser==2.22
@@ -225,6 +378,10 @@ pygments==2.19.1
     #   diff-cover
     #   readme-renderer
     #   rich
+pyjwt[crypto]==2.10.1
+    # via
+    #   -r requirements/quality.txt
+    #   firebase-admin
 pylint==3.3.4
     # via
     #   -r requirements/quality.txt
@@ -249,6 +406,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
+pyparsing==3.2.3
+    # via
+    #   -r requirements/quality.txt
+    #   httplib2
 pyproject-api==1.9.0
     # via
     #   -r requirements/ci.txt
@@ -264,6 +425,10 @@ pytest==8.3.5
     #   pytest-cov
 pytest-cov==6.0.0
     # via -r requirements/quality.txt
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-ace
 python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt
@@ -280,9 +445,13 @@ readme-renderer==44.0
 requests==2.32.3
     # via
     #   -r requirements/quality.txt
+    #   cachecontrol
+    #   google-api-core
+    #   google-cloud-storage
     #   id
     #   requests-toolbelt
     #   responses
+    #   sailthru-client
     #   twine
 requests-toolbelt==1.0.0
     # via
@@ -298,10 +467,28 @@ rich==13.9.4
     # via
     #   -r requirements/quality.txt
     #   twine
+rsa==4.9.1
+    # via
+    #   -r requirements/quality.txt
+    #   google-auth
+sailthru-client==2.2.3
+    # via
+    #   -r requirements/quality.txt
+    #   edx-ace
+simplejson==3.20.1
+    # via
+    #   -r requirements/quality.txt
+    #   sailthru-client
 six==1.17.0
     # via
     #   -r requirements/quality.txt
+    #   edx-ace
     #   edx-lint
+    #   python-dateutil
+sniffio==1.3.1
+    # via
+    #   -r requirements/quality.txt
+    #   anyio
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
@@ -314,6 +501,7 @@ stevedore==5.4.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
+    #   edx-ace
     #   edx-django-utils
 text-unidecode==1.3
     # via
@@ -327,6 +515,14 @@ tox==4.24.1
     # via -r requirements/ci.txt
 twine==6.1.0
     # via -r requirements/quality.txt
+typing-extensions==4.14.0
+    # via
+    #   -r requirements/quality.txt
+    #   anyio
+uritemplate==4.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   google-api-python-client
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+anyio==4.9.0
+    # via
+    #   -r requirements/test.txt
+    #   httpx
 asgiref==3.8.1
     # via
     #   -r requirements/test.txt
@@ -12,15 +16,30 @@ astroid==3.3.8
     # via
     #   pylint
     #   pylint-celery
+attrs==25.3.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-ace
 backports-tarfile==1.2.0
     # via jaraco-context
+cachecontrol==0.14.3
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+cachetools==5.5.2
+    # via
+    #   -r requirements/test.txt
+    #   google-auth
 certifi==2025.1.31
     # via
     #   -r requirements/test.txt
+    #   httpcore
+    #   httpx
     #   requests
 cffi==1.17.1
     # via
     #   -r requirements/test.txt
+    #   cryptography
     #   pynacl
 charset-normalizer==3.4.1
     # via
@@ -41,6 +60,10 @@ coverage[toml]==7.6.12
     # via
     #   -r requirements/test.txt
     #   pytest-cov
+cryptography==45.0.4
+    # via
+    #   -r requirements/test.txt
+    #   pyjwt
 ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.3.9
@@ -50,27 +73,133 @@ django==4.2.20
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   django-crum
+    #   django-push-notifications
     #   django-waffle
+    #   edx-ace
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+django-push-notifications==3.2.1
+    # via
+    #   -r requirements/test.txt
+    #   edx-ace
 django-waffle==4.2.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
 docutils==0.21.2
     # via readme-renderer
-edx-django-utils==7.2.0
+edx-ace==1.15.0
     # via -r requirements/test.txt
+edx-django-utils==7.2.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-ace
 edx-lint==5.6.0
     # via -r requirements/quality.in
+firebase-admin==6.9.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-ace
+google-api-core[grpc]==2.25.1
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.174.0
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+google-auth==2.40.3
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-python-client
+google-cloud-core==2.4.3
+    # via
+    #   -r requirements/test.txt
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.21.0
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+google-cloud-storage==3.1.1
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+google-crc32c==1.7.1
+    # via
+    #   -r requirements/test.txt
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via
+    #   -r requirements/test.txt
+    #   google-cloud-storage
+googleapis-common-protos==1.70.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.73.1
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.73.1
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+h11==0.16.0
+    # via
+    #   -r requirements/test.txt
+    #   httpcore
+h2==4.2.0
+    # via
+    #   -r requirements/test.txt
+    #   httpx
+hpack==4.1.0
+    # via
+    #   -r requirements/test.txt
+    #   h2
+httpcore==1.0.9
+    # via
+    #   -r requirements/test.txt
+    #   httpx
+httplib2==0.22.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-python-client
+    #   google-auth-httplib2
+httpx[http2]==0.28.1
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+hyperframe==6.1.0
+    # via
+    #   -r requirements/test.txt
+    #   h2
 id==1.5.0
     # via twine
 idna==3.10
     # via
     #   -r requirements/test.txt
+    #   anyio
+    #   httpx
     #   requests
 importlib-metadata==8.6.1
     # via keyring
@@ -104,6 +233,10 @@ more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
+msgpack==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   cachecontrol
 newrelic==10.7.0
     # via
     #   -r requirements/test.txt
@@ -125,10 +258,32 @@ pluggy==1.5.0
     # via
     #   -r requirements/test.txt
     #   pytest
+proto-plus==1.26.1
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==6.31.1
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
 psutil==7.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+pyasn1==0.6.1
+    # via
+    #   -r requirements/test.txt
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.2
+    # via
+    #   -r requirements/test.txt
+    #   google-auth
 pycodestyle==2.12.1
     # via -r requirements/quality.in
 pycparser==2.22
@@ -141,6 +296,10 @@ pygments==2.19.1
     # via
     #   readme-renderer
     #   rich
+pyjwt[crypto]==2.10.1
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
 pylint==3.3.4
     # via
     #   edx-lint
@@ -159,12 +318,20 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+pyparsing==3.2.3
+    # via
+    #   -r requirements/test.txt
+    #   httplib2
 pytest==8.3.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 pytest-cov==6.0.0
     # via -r requirements/test.txt
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements/test.txt
+    #   edx-ace
 python-slugify==8.0.4
     # via code-annotations
 pyyaml==6.0.2
@@ -177,9 +344,13 @@ readme-renderer==44.0
 requests==2.32.3
     # via
     #   -r requirements/test.txt
+    #   cachecontrol
+    #   google-api-core
+    #   google-cloud-storage
     #   id
     #   requests-toolbelt
     #   responses
+    #   sailthru-client
     #   twine
 requests-toolbelt==1.0.0
     # via twine
@@ -189,8 +360,28 @@ rfc3986==2.0.0
     # via twine
 rich==13.9.4
     # via twine
+rsa==4.9.1
+    # via
+    #   -r requirements/test.txt
+    #   google-auth
+sailthru-client==2.2.3
+    # via
+    #   -r requirements/test.txt
+    #   edx-ace
+simplejson==3.20.1
+    # via
+    #   -r requirements/test.txt
+    #   sailthru-client
 six==1.17.0
-    # via edx-lint
+    # via
+    #   -r requirements/test.txt
+    #   edx-ace
+    #   edx-lint
+    #   python-dateutil
+sniffio==1.3.1
+    # via
+    #   -r requirements/test.txt
+    #   anyio
 snowballstemmer==2.2.0
     # via pydocstyle
 sqlparse==0.5.3
@@ -201,6 +392,7 @@ stevedore==5.4.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   edx-ace
     #   edx-django-utils
 text-unidecode==1.3
     # via python-slugify
@@ -208,6 +400,14 @@ tomlkit==0.13.2
     # via pylint
 twine==6.1.0
     # via -r requirements/quality.in
+typing-extensions==4.14.0
+    # via
+    #   -r requirements/test.txt
+    #   anyio
+uritemplate==4.2.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-python-client
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,16 +4,35 @@
 #
 #    make upgrade
 #
+anyio==4.9.0
+    # via
+    #   -r requirements/base.txt
+    #   httpx
     # via
     #   -r requirements/base.txt
     #   django
+attrs==25.3.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-ace
+cachecontrol==0.14.3
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+cachetools==5.5.2
+    # via
+    #   -r requirements/base.txt
+    #   google-auth
 certifi==2025.1.31
     # via
     #   -r requirements/base.txt
+    #   httpcore
+    #   httpx
     #   requests
 cffi==1.17.1
     # via
     #   -r requirements/base.txt
+    #   cryptography
     #   pynacl
 charset-normalizer==3.4.1
     # via
@@ -25,30 +44,144 @@ click==8.1.8
     #   edx-django-utils
 coverage[toml]==7.6.12
     # via pytest-cov
+cryptography==45.0.4
+    # via
+    #   -r requirements/base.txt
+    #   pyjwt
 ddt==1.7.2
     # via -r requirements/test.in
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   django-crum
+    #   django-push-notifications
     #   django-waffle
+    #   edx-ace
     #   edx-django-utils
 django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+django-push-notifications==3.2.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-ace
 django-waffle==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-edx-django-utils==7.2.0
+edx-ace==1.15.0
     # via -r requirements/base.txt
+edx-django-utils==7.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-ace
+firebase-admin==6.9.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-ace
+google-api-core[grpc]==2.25.1
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.174.0
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-auth==2.40.3
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-python-client
+google-cloud-core==2.4.3
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.21.0
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-cloud-storage==3.1.1
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-crc32c==1.7.1
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-storage
+googleapis-common-protos==1.70.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.73.1
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.73.1
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+h11==0.16.0
+    # via
+    #   -r requirements/base.txt
+    #   httpcore
+h2==4.2.0
+    # via
+    #   -r requirements/base.txt
+    #   httpx
+hpack==4.1.0
+    # via
+    #   -r requirements/base.txt
+    #   h2
+httpcore==1.0.9
+    # via
+    #   -r requirements/base.txt
+    #   httpx
+httplib2==0.22.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-python-client
+    #   google-auth-httplib2
+httpx[http2]==0.28.1
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+hyperframe==6.1.0
+    # via
+    #   -r requirements/base.txt
+    #   h2
 idna==3.10
     # via
     #   -r requirements/base.txt
+    #   anyio
+    #   httpx
     #   requests
 iniconfig==2.0.0
     # via pytest
+msgpack==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   cachecontrol
 newrelic==10.7.0
     # via
     #   -r requirements/base.txt
@@ -61,30 +194,89 @@ pbr==6.1.1
     #   stevedore
 pluggy==1.5.0
     # via pytest
+proto-plus==1.26.1
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==6.31.1
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
 psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+pyasn1==0.6.1
+    # via
+    #   -r requirements/base.txt
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.2
+    # via
+    #   -r requirements/base.txt
+    #   google-auth
 pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
+pyjwt[crypto]==2.10.1
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
 pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+pyparsing==3.2.3
+    # via
+    #   -r requirements/base.txt
+    #   httplib2
 pytest==8.3.5
     # via pytest-cov
 pytest-cov==6.0.0
     # via -r requirements/test.in
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements/base.txt
+    #   edx-ace
 pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via
     #   -r requirements/base.txt
+    #   cachecontrol
+    #   google-api-core
+    #   google-cloud-storage
     #   responses
+    #   sailthru-client
 responses==0.25.6
     # via -r requirements/test.in
+rsa==4.9.1
+    # via
+    #   -r requirements/base.txt
+    #   google-auth
+sailthru-client==2.2.3
+    # via
+    #   -r requirements/base.txt
+    #   edx-ace
+simplejson==3.20.1
+    # via
+    #   -r requirements/base.txt
+    #   sailthru-client
+six==1.17.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-ace
+    #   python-dateutil
+sniffio==1.3.1
+    # via
+    #   -r requirements/base.txt
+    #   anyio
 sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
@@ -92,7 +284,16 @@ sqlparse==0.5.3
 stevedore==5.4.1
     # via
     #   -r requirements/base.txt
+    #   edx-ace
     #   edx-django-utils
+typing-extensions==4.14.0
+    # via
+    #   -r requirements/base.txt
+    #   anyio
+uritemplate==4.2.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-python-client
 urllib3==2.2.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,9 @@ setup(
         'cms.djangoapp': [
             'braze = braze.apps:BrazeAppConfig',
         ],
+        'openedx.ace.channel': [
+            'braze_push = braze.ace_channel.braze_push_channel:BrazePushNotificationChannel'
+        ],
     },
     include_package_data=True,
     install_requires=load_requirements('requirements/base.in'),


### PR DESCRIPTION
Added ace channel for braze messages. Sending ace messages using braze belongs to this repo than anywhere else. We can't add this logic to edx-ace or core platform because braze isn't in approved vendors list for openedx. For more context on this, look at this https://github.com/openedx/edx-platform/pull/36272.