### PR TITLE
fix: handle keyerror in Braze push notification channel

### DIFF
--- a/braze/ace_channel/braze_push_channel.py
+++ b/braze/ace_channel/braze_push_channel.py
@@ -36,7 +36,7 @@ class BrazePushNotificationChannel(Channel):
             rendered_message: The rendered content of the message that has been personalized
                 for this particular recipient.
         """
-        notification_type = message.options['notification_type']
+        notification_type = message.options.get('notification_type')
         emails = message.options.get('emails') or [message.recipient.email_address]
         campaign_id = self._campaign_id(notification_type)
         if not campaign_id:
@@ -47,7 +47,7 @@ class BrazePushNotificationChannel(Channel):
             braze_client = self.get_braze_client()
             braze_client.send_campaign_message(
                 campaign_id=campaign_id,
-                trigger_properties=message.context['post_data'],
+                trigger_properties=message.context.get('post_data'),
                 emails=emails
             )
             LOG.info('Sent push notification for %s with Braze', notification_type)


### PR DESCRIPTION
**Description**

- This PR updates the `BrazePushNotificationChannel` to safely access optional keys in the message payload using `.get()` to prevent KeyError exceptions.

**Reason**

- With the recent migration from `edx_ace` to `braze_client`, the expected payload format has changed. Missing keys like `notification_type` and `post_data` were causing failures when sending notifications. This update ensures compatibility and improves reliability when the payload is incomplete or different.

**Jira**

- https://2u-internal.atlassian.net/browse/TNL2-344

**Screenshot**

<img width="1193" height="399" alt="image" src="https://github.com/user-attachments/assets/28e8c035-8e48-4317-b8ee-cbf592ffc674" />
